### PR TITLE
Add whitelist filtering feature for process output suppression

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ sudo ./egress-tracer --json                    # JSON output
 sudo ./egress-tracer --cache-ttl=10m           # PID Cache TTL
 sudo ./egress-tracer --cache-max-size=500      # PID Cache size
 
+# Whitelist filtering (suppress output for specific processes)
+sudo ./egress-tracer --whitelist=whitelist.txt # Load SHA256 whitelist from file
+
 # Rotating JSONL Logging
 sudo ./egress-tracer --log-file=/var/log/egress-tracer.jsonl          # Enable rotating JSONL logging
 sudo ./egress-tracer --log-file=/var/log/egress-tracer.jsonl \
@@ -45,6 +48,51 @@ sudo ./egress-tracer --log-file=/var/log/egress-tracer.jsonl \
                     --log-max-files=10                         # Max number of rotated files
 
 
+```
+
+## Whitelist Filtering
+
+The whitelist feature allows you to suppress output for specific processes based on their SHA256 hash.
+
+### Whitelist File Format
+
+Create a text file with one SHA256 hash per line:
+
+```
+# Whitelist file for egress-tracer
+# Lines starting with # are comments
+# Empty lines are ignored
+
+d4f7c9e8a1b2c3d4e5f6789012345678901234567890123456789012345678901234
+a1b2c3d4e5f6789012345678901234567890123456789012345678901234567890123
+```
+
+### Getting Process SHA256 Hashes
+
+To get the SHA256 hash of a process:
+
+```bash
+# Find process by name
+ps aux | grep process_name
+
+# Get SHA256 of the executable
+sha256sum /path/to/executable
+
+# Or use the tracer in JSON mode to see hashes
+sudo ./egress-tracer --json | jq -r '.process_sha256' | sort -u
+```
+
+### Usage Examples
+
+```bash
+# CLI mode with whitelist
+sudo ./egress-tracer --whitelist=trusted_processes.txt
+
+# TUI mode with whitelist  
+sudo ./egress-tracer --tui --whitelist=trusted_processes.txt
+
+# JSON logging with whitelist
+sudo ./egress-tracer --json --whitelist=trusted_processes.txt --log-file=events.jsonl
 ```
 
 ## Project Structure

--- a/README.md
+++ b/README.md
@@ -34,9 +34,7 @@ sudo ./egress-tracer
 sudo ./egress-tracer --tui
 
 # Options for CLI mode
-sudo ./egress-tracer --json                    # JSON output  
-sudo ./egress-tracer --cache-ttl=10m           # PID Cache TTL
-sudo ./egress-tracer --cache-max-size=500      # PID Cache size
+sudo ./egress-tracer --json                    # JSON output
 
 # Whitelist filtering (suppress output for specific processes)
 sudo ./egress-tracer --whitelist=whitelist.txt # Load SHA256 whitelist from file
@@ -47,6 +45,9 @@ sudo ./egress-tracer --log-file=/var/log/egress-tracer.jsonl \
                     --log-max-size=52428800 \                  # Max file size before rotation (50MB)
                     --log-max-files=10                         # Max number of rotated files
 
+# Process Cache which offloads /proc lookups
+sudo ./egress-tracer --cache-ttl=10m           # PID Cache TTL
+sudo ./egress-tracer --cache-max-size=500      # PID Cache size
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ sudo apt install -y \
 ## Build
 
 ```bash
-# Build main binary
-make build
+make clean && make build && ./egress-tracer -h
 ```
 
 ## Usage (requires root privileges)
@@ -32,6 +31,10 @@ sudo ./egress-tracer
 
 # TUI mode (Terminal User Interface)
 sudo ./egress-tracer --tui
+
+# TUI with a whitelist and removing connections from view after 30 seconds
+sudo ./egress-tracer -whitelist whitelist.txt -tui -tui-cache-ttl 30s
+```
 
 # Options for CLI mode
 sudo ./egress-tracer --json                    # JSON output
@@ -53,7 +56,11 @@ sudo ./egress-tracer --cache-max-size=500      # PID Cache size
 
 ## Whitelist Filtering
 
-The whitelist feature allows you to suppress output for specific processes based on their SHA256 hash.
+The whitelist feature allows you to suppress output for specific processes based on their SHA256 hash. Whitelist entries can be loaded from a file at startup or added interactively via the TUI.
+
+### Interactive TUI Management
+
+In TUI mode with `--whitelist` parameter, press `w` on any connection to add its process to the whitelist: **Requires starting with `--whitelist=filename`**. Changes are saved to the specified whitelist file and take effect immediately.
 
 ### Whitelist File Format
 
@@ -68,33 +75,20 @@ d4f7c9e8a1b2c3d4e5f6789012345678901234567890123456789012345678901234
 a1b2c3d4e5f6789012345678901234567890123456789012345678901234567890123
 ```
 
-### Getting Process SHA256 Hashes
-
-To get the SHA256 hash of a process:
-
-```bash
-# Find process by name
-ps aux | grep process_name
-
-# Get SHA256 of the executable
-sha256sum /path/to/executable
-
-# Or use the tracer in JSON mode to see hashes
-sudo ./egress-tracer --json | jq -r '.process_sha256' | sort -u
-```
-
 ### Usage Examples
 
 ```bash
 # CLI mode with whitelist
 sudo ./egress-tracer --whitelist=trusted_processes.txt
 
-# TUI mode with whitelist  
+# TUI mode with whitelist (enables interactive 'w' key - requires --whitelist parameter)
 sudo ./egress-tracer --tui --whitelist=trusted_processes.txt
 
 # JSON logging with whitelist
 sudo ./egress-tracer --json --whitelist=trusted_processes.txt --log-file=events.jsonl
 ```
+
+**Note**: If the whitelist file doesn't exist, you'll be prompted to create it automatically.
 
 ## Project Structure
 

--- a/cmd/procnet/main.go
+++ b/cmd/procnet/main.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 	"unsafe"
@@ -19,6 +20,7 @@ import (
 	"github.com/cilium/ebpf/ringbuf"
 	"github.com/clwg/egress-tracer/pkg/cache"
 	"github.com/clwg/egress-tracer/pkg/ebpf"
+	"github.com/clwg/egress-tracer/pkg/filter"
 	"github.com/clwg/egress-tracer/pkg/logger"
 	"github.com/clwg/egress-tracer/pkg/output"
 	"github.com/clwg/egress-tracer/pkg/tui"
@@ -57,6 +59,10 @@ func main() {
 	// Load whitelist if specified
 	if *whitelistFile != "" {
 		if err := processCache.LoadWhitelistFromFile(*whitelistFile); err != nil {
+			var fileNotExistErr *filter.FileNotExistError
+			if errors.As(err, &fileNotExistErr) {
+				log.Fatalf("Whitelist file does not exist: %s\nPlease create the file or use --whitelist=\"\" to disable filtering.", *whitelistFile)
+			}
 			log.Fatalf("Loading whitelist file: %v", err)
 		}
 		log.Printf("Loaded whitelist from %s (%d hashes)", *whitelistFile, processCache.GetWhitelistFilter().GetHashCount())
@@ -149,9 +155,34 @@ func runTUI(cacheTTL time.Duration, cacheMaxSize int, tuiCacheMaxSize int, tuiCa
 	// Load whitelist if specified
 	if whitelistFile != "" {
 		if err := processCache.LoadWhitelistFromFile(whitelistFile); err != nil {
-			log.Fatalf("Loading whitelist file: %v", err)
+			var fileNotExistErr *filter.FileNotExistError
+			if errors.As(err, &fileNotExistErr) {
+				// Prompt user to create the file
+				fmt.Printf("Whitelist file does not exist: %s\n", whitelistFile)
+				fmt.Print("Would you like to create it? (y/N): ")
+				
+				var response string
+				fmt.Scanln(&response)
+				
+				if strings.ToLower(strings.TrimSpace(response)) == "y" {
+					if err := filter.CreateWhitelistFile(whitelistFile); err != nil {
+						log.Fatalf("Failed to create whitelist file: %v", err)
+					}
+					fmt.Printf("Created whitelist file: %s\n", whitelistFile)
+					// Load the newly created file
+					if err := processCache.LoadWhitelistFromFile(whitelistFile); err != nil {
+						log.Fatalf("Failed to load newly created whitelist file: %v", err)
+					}
+				} else {
+					fmt.Println("Continuing without whitelist filtering...")
+					whitelistFile = "" // Disable whitelist
+				}
+			} else {
+				log.Fatalf("Loading whitelist file: %v", err)
+			}
+		} else {
+			log.Printf("Loaded whitelist from %s (%d hashes)", whitelistFile, processCache.GetWhitelistFilter().GetHashCount())
 		}
-		log.Printf("Loaded whitelist from %s (%d hashes)", whitelistFile, processCache.GetWhitelistFilter().GetHashCount())
 	}
 
 	// Create eBPF tracer

--- a/cmd/procnet/main.go
+++ b/cmd/procnet/main.go
@@ -162,7 +162,7 @@ func runTUI(cacheTTL time.Duration, cacheMaxSize int, tuiCacheMaxSize int, tuiCa
 	defer tracer.Close()
 
 	// Initialize TUI model
-	model := tui.NewModel(tuiCacheMaxSize, tuiCacheTTL)
+	model := tui.NewModelWithCache(tuiCacheMaxSize, tuiCacheTTL, processCache, whitelistFile)
 
 	// Create context for graceful shutdown
 	ctx, cancel := context.WithCancel(context.Background())

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 )
 
 require (
+	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
 	github.com/charmbracelet/x/ansi v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
+github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/aymanbagabas/go-udiff v0.2.0 h1:TK0fH4MteXUDspT88n8CKzvK0X9O2xu9yQjWpi6yML8=

--- a/pkg/filter/whitelist.go
+++ b/pkg/filter/whitelist.go
@@ -4,9 +4,19 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 )
+
+// FileNotExistError is returned when the whitelist file doesn't exist
+type FileNotExistError struct {
+	Path string
+}
+
+func (e *FileNotExistError) Error() string {
+	return fmt.Sprintf("whitelist file does not exist: %s", e.Path)
+}
 
 // WhitelistFilter manages SHA256 hashes for process filtering
 type WhitelistFilter struct {
@@ -26,6 +36,10 @@ func NewWhitelistFilter() *WhitelistFilter {
 func (wf *WhitelistFilter) LoadFromFile(filePath string) error {
 	file, err := os.Open(filePath)
 	if err != nil {
+		if os.IsNotExist(err) {
+			// File doesn't exist, return a special error that can be handled
+			return &FileNotExistError{Path: filePath}
+		}
 		return fmt.Errorf("failed to open whitelist file: %w", err)
 	}
 	defer file.Close()
@@ -38,28 +52,28 @@ func (wf *WhitelistFilter) LoadFromFile(filePath string) error {
 
 	scanner := bufio.NewScanner(file)
 	lineNum := 0
-	
+
 	for scanner.Scan() {
 		lineNum++
 		line := strings.TrimSpace(scanner.Text())
-		
+
 		// Skip empty lines and comments
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
-		
+
 		// Validate SHA256 format (64 hex characters)
 		if len(line) != 64 {
 			return fmt.Errorf("invalid SHA256 hash at line %d: %s (must be 64 hex characters)", lineNum, line)
 		}
-		
+
 		// Validate hex characters
 		for _, char := range line {
 			if !((char >= '0' && char <= '9') || (char >= 'a' && char <= 'f') || (char >= 'A' && char <= 'F')) {
 				return fmt.Errorf("invalid SHA256 hash at line %d: %s (contains non-hex characters)", lineNum, line)
 			}
 		}
-		
+
 		// Convert to lowercase for consistent matching
 		wf.hashes[strings.ToLower(line)] = true
 	}
@@ -76,10 +90,10 @@ func (wf *WhitelistFilter) IsWhitelisted(sha256Hash string) bool {
 	if sha256Hash == "" {
 		return false
 	}
-	
+
 	wf.mutex.RLock()
 	defer wf.mutex.RUnlock()
-	
+
 	// Convert to lowercase for consistent matching
 	return wf.hashes[strings.ToLower(sha256Hash)]
 }
@@ -89,17 +103,17 @@ func (wf *WhitelistFilter) AddHash(sha256Hash string) error {
 	if len(sha256Hash) != 64 {
 		return fmt.Errorf("invalid SHA256 hash: %s (must be 64 hex characters)", sha256Hash)
 	}
-	
+
 	// Validate hex characters
 	for _, char := range sha256Hash {
 		if !((char >= '0' && char <= '9') || (char >= 'a' && char <= 'f') || (char >= 'A' && char <= 'F')) {
 			return fmt.Errorf("invalid SHA256 hash: %s (contains non-hex characters)", sha256Hash)
 		}
 	}
-	
+
 	wf.mutex.Lock()
 	defer wf.mutex.Unlock()
-	
+
 	wf.hashes[strings.ToLower(sha256Hash)] = true
 	return nil
 }
@@ -108,7 +122,7 @@ func (wf *WhitelistFilter) AddHash(sha256Hash string) error {
 func (wf *WhitelistFilter) RemoveHash(sha256Hash string) {
 	wf.mutex.Lock()
 	defer wf.mutex.Unlock()
-	
+
 	delete(wf.hashes, strings.ToLower(sha256Hash))
 }
 
@@ -116,7 +130,7 @@ func (wf *WhitelistFilter) RemoveHash(sha256Hash string) {
 func (wf *WhitelistFilter) GetHashCount() int {
 	wf.mutex.RLock()
 	defer wf.mutex.RUnlock()
-	
+
 	return len(wf.hashes)
 }
 
@@ -124,12 +138,12 @@ func (wf *WhitelistFilter) GetHashCount() int {
 func (wf *WhitelistFilter) GetAllHashes() []string {
 	wf.mutex.RLock()
 	defer wf.mutex.RUnlock()
-	
+
 	hashes := make([]string, 0, len(wf.hashes))
 	for hash := range wf.hashes {
 		hashes = append(hashes, hash)
 	}
-	
+
 	return hashes
 }
 
@@ -137,11 +151,34 @@ func (wf *WhitelistFilter) GetAllHashes() []string {
 func (wf *WhitelistFilter) Clear() {
 	wf.mutex.Lock()
 	defer wf.mutex.Unlock()
-	
+
 	wf.hashes = make(map[string]bool)
 }
 
 // ReloadFromFile reloads the whitelist from a file
 func (wf *WhitelistFilter) ReloadFromFile(filePath string) error {
 	return wf.LoadFromFile(filePath)
+}
+
+// CreateWhitelistFile creates a new whitelist file with a default header
+func CreateWhitelistFile(filePath string) error {
+	// Create directory if it doesn't exist
+	dir := filepath.Dir(filePath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+
+	// Create the file with default content
+	content := `# Whitelist file for egress-tracer
+# One SHA256 hash per line
+# Lines starting with # are comments and will be ignored
+# Empty lines are also ignored
+
+`
+
+	if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
+		return fmt.Errorf("failed to create whitelist file: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/filter/whitelist.go
+++ b/pkg/filter/whitelist.go
@@ -1,0 +1,147 @@
+package filter
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+)
+
+// WhitelistFilter manages SHA256 hashes for process filtering
+type WhitelistFilter struct {
+	hashes map[string]bool
+	mutex  sync.RWMutex
+}
+
+// NewWhitelistFilter creates a new whitelist filter
+func NewWhitelistFilter() *WhitelistFilter {
+	return &WhitelistFilter{
+		hashes: make(map[string]bool),
+	}
+}
+
+// LoadFromFile loads SHA256 hashes from a file
+// File format: one SHA256 hash per line, comments start with #
+func (wf *WhitelistFilter) LoadFromFile(filePath string) error {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to open whitelist file: %w", err)
+	}
+	defer file.Close()
+
+	wf.mutex.Lock()
+	defer wf.mutex.Unlock()
+
+	// Clear existing hashes
+	wf.hashes = make(map[string]bool)
+
+	scanner := bufio.NewScanner(file)
+	lineNum := 0
+	
+	for scanner.Scan() {
+		lineNum++
+		line := strings.TrimSpace(scanner.Text())
+		
+		// Skip empty lines and comments
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		
+		// Validate SHA256 format (64 hex characters)
+		if len(line) != 64 {
+			return fmt.Errorf("invalid SHA256 hash at line %d: %s (must be 64 hex characters)", lineNum, line)
+		}
+		
+		// Validate hex characters
+		for _, char := range line {
+			if !((char >= '0' && char <= '9') || (char >= 'a' && char <= 'f') || (char >= 'A' && char <= 'F')) {
+				return fmt.Errorf("invalid SHA256 hash at line %d: %s (contains non-hex characters)", lineNum, line)
+			}
+		}
+		
+		// Convert to lowercase for consistent matching
+		wf.hashes[strings.ToLower(line)] = true
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("error reading whitelist file: %w", err)
+	}
+
+	return nil
+}
+
+// IsWhitelisted checks if a SHA256 hash is in the whitelist
+func (wf *WhitelistFilter) IsWhitelisted(sha256Hash string) bool {
+	if sha256Hash == "" {
+		return false
+	}
+	
+	wf.mutex.RLock()
+	defer wf.mutex.RUnlock()
+	
+	// Convert to lowercase for consistent matching
+	return wf.hashes[strings.ToLower(sha256Hash)]
+}
+
+// AddHash adds a SHA256 hash to the whitelist
+func (wf *WhitelistFilter) AddHash(sha256Hash string) error {
+	if len(sha256Hash) != 64 {
+		return fmt.Errorf("invalid SHA256 hash: %s (must be 64 hex characters)", sha256Hash)
+	}
+	
+	// Validate hex characters
+	for _, char := range sha256Hash {
+		if !((char >= '0' && char <= '9') || (char >= 'a' && char <= 'f') || (char >= 'A' && char <= 'F')) {
+			return fmt.Errorf("invalid SHA256 hash: %s (contains non-hex characters)", sha256Hash)
+		}
+	}
+	
+	wf.mutex.Lock()
+	defer wf.mutex.Unlock()
+	
+	wf.hashes[strings.ToLower(sha256Hash)] = true
+	return nil
+}
+
+// RemoveHash removes a SHA256 hash from the whitelist
+func (wf *WhitelistFilter) RemoveHash(sha256Hash string) {
+	wf.mutex.Lock()
+	defer wf.mutex.Unlock()
+	
+	delete(wf.hashes, strings.ToLower(sha256Hash))
+}
+
+// GetHashCount returns the number of hashes in the whitelist
+func (wf *WhitelistFilter) GetHashCount() int {
+	wf.mutex.RLock()
+	defer wf.mutex.RUnlock()
+	
+	return len(wf.hashes)
+}
+
+// GetAllHashes returns all hashes in the whitelist
+func (wf *WhitelistFilter) GetAllHashes() []string {
+	wf.mutex.RLock()
+	defer wf.mutex.RUnlock()
+	
+	hashes := make([]string, 0, len(wf.hashes))
+	for hash := range wf.hashes {
+		hashes = append(hashes, hash)
+	}
+	
+	return hashes
+}
+
+// Clear removes all hashes from the whitelist
+func (wf *WhitelistFilter) Clear() {
+	wf.mutex.Lock()
+	defer wf.mutex.Unlock()
+	
+	wf.hashes = make(map[string]bool)
+}
+
+// ReloadFromFile reloads the whitelist from a file
+func (wf *WhitelistFilter) ReloadFromFile(filePath string) error {
+	return wf.LoadFromFile(filePath)
+}

--- a/pkg/filter/whitelist.go
+++ b/pkg/filter/whitelist.go
@@ -173,7 +173,6 @@ func CreateWhitelistFile(filePath string) error {
 # One SHA256 hash per line
 # Lines starting with # are comments and will be ignored
 # Empty lines are also ignored
-
 `
 
 	if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -2,13 +2,16 @@ package tui
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"time"
 
 	"github.com/charmbracelet/bubbles/table"
+	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/clwg/egress-tracer/pkg/cache"
 	"github.com/clwg/egress-tracer/pkg/types"
 )
 
@@ -25,6 +28,13 @@ const (
 	sortBySHA256
 )
 
+type popupType int
+
+const (
+	popupDetails popupType = iota
+	popupWhitelist
+)
+
 type ConnectionData struct {
 	Event     *types.Event
 	Count     int
@@ -33,20 +43,25 @@ type ConnectionData struct {
 }
 
 type Model struct {
-	table          table.Model
-	connections    map[string]*ConnectionData
-	sortBy         sortColumn
-	sortDesc       bool
-	totalEvents    int
-	startTime      time.Time
-	selectedRow    int
-	width          int
-	height         int
-	showPopup      bool
-	popupData      *ConnectionData
-	cacheMaxSize   int
-	cacheTTL       time.Duration
-	lastCleanup    time.Time
+	table               table.Model
+	connections         map[string]*ConnectionData
+	sortBy              sortColumn
+	sortDesc            bool
+	totalEvents         int
+	startTime           time.Time
+	selectedRow         int
+	width               int
+	height              int
+	showPopup           bool
+	popupType           popupType
+	popupData           *ConnectionData
+	cacheMaxSize        int
+	cacheTTL            time.Duration
+	lastCleanup         time.Time
+	processCache        *cache.ProcessCache
+	whitelistFile       string
+	whitelistInput      textinput.Model
+	whitelistConfirming bool
 }
 
 type EventMsg struct {
@@ -62,6 +77,10 @@ func tickCmd() tea.Cmd {
 }
 
 func NewModel(cacheMaxSize int, cacheTTL time.Duration) Model {
+	return NewModelWithCache(cacheMaxSize, cacheTTL, nil, "")
+}
+
+func NewModelWithCache(cacheMaxSize int, cacheTTL time.Duration, processCache *cache.ProcessCache, whitelistFile string) Model {
 	// Initialize with default column headers (will be updated dynamically)
 	columns := []table.Column{
 		{Title: "Process", Width: 19},
@@ -92,15 +111,24 @@ func NewModel(cacheMaxSize int, cacheTTL time.Duration) Model {
 		Bold(false)
 	t.SetStyles(s)
 
+	// Initialize text input for whitelist comments
+	ti := textinput.New()
+	ti.Placeholder = "Enter description for whitelist entry..."
+	ti.CharLimit = 100
+	ti.Width = 50
+
 	m := Model{
-		table:        t,
-		connections:  make(map[string]*ConnectionData),
-		sortBy:       sortByLastSeen,
-		sortDesc:     true,
-		startTime:    time.Now(),
-		cacheMaxSize: cacheMaxSize,
-		cacheTTL:     cacheTTL,
-		lastCleanup:  time.Now(),
+		table:          t,
+		connections:    make(map[string]*ConnectionData),
+		sortBy:         sortByLastSeen,
+		sortDesc:       true,
+		startTime:      time.Now(),
+		cacheMaxSize:   cacheMaxSize,
+		cacheTTL:       cacheTTL,
+		lastCleanup:    time.Now(),
+		processCache:   processCache,
+		whitelistFile:  whitelistFile,
+		whitelistInput: ti,
 	}
 
 	// Set initial column headers with sort indicators
@@ -143,16 +171,49 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 
 		case "enter":
-			if !m.showPopup {
+			if m.showPopup && m.popupType == popupWhitelist && !m.whitelistConfirming {
+				// First enter - confirm the whitelist entry
+				m.whitelistConfirming = true
+				return m, nil
+			} else if m.showPopup && m.popupType == popupWhitelist && m.whitelistConfirming {
+				// Second enter - actually add to whitelist
+				if err := m.addToWhitelist(); err != nil {
+					// TODO: Show error message - for now just close popup
+				}
+				m.showPopup = false
+				m.popupType = popupDetails
+				m.popupData = nil
+				m.whitelistConfirming = false
+				m.whitelistInput.SetValue("")
+				return m, nil
+			} else if !m.showPopup {
 				m.showPopup = true
+				m.popupType = popupDetails
 				m.popupData = m.getSelectedConnection()
+			}
+			return m, nil
+
+		case "w":
+			if !m.showPopup && m.whitelistFile != "" {
+				// Open whitelist popup for selected connection (only if whitelist is configured)
+				selectedData := m.getSelectedConnection()
+				if selectedData != nil && selectedData.Event.ProcessSHA256 != "" {
+					m.showPopup = true
+					m.popupType = popupWhitelist
+					m.popupData = selectedData
+					m.whitelistInput.Focus()
+				}
 			}
 			return m, nil
 
 		case "esc":
 			if m.showPopup {
 				m.showPopup = false
+				m.popupType = popupDetails
 				m.popupData = nil
+				m.whitelistConfirming = false
+				m.whitelistInput.SetValue("")
+				m.whitelistInput.Blur()
 			}
 			return m, nil
 
@@ -225,13 +286,19 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	if !m.showPopup {
 		m.table, cmd = m.table.Update(msg)
+	} else if m.showPopup && m.popupType == popupWhitelist {
+		// Handle text input for whitelist popup
+		m.whitelistInput, cmd = m.whitelistInput.Update(msg)
 	}
 	return m, cmd
 }
 
 func (m *Model) View() string {
 	if m.showPopup && m.popupData != nil {
-		return m.renderPopup()
+		if m.popupType == popupWhitelist {
+			return m.renderWhitelistPopup()
+		}
+		return m.renderDetailsPopup()
 	}
 
 	var b strings.Builder
@@ -258,7 +325,13 @@ func (m *Model) View() string {
 		Foreground(lipgloss.Color("241")).
 		Padding(0, 1)
 
-	help := helpStyle.Render("Keys: 1-8 sort columns | r reset | enter details | q quit")
+	var helpText string
+	if m.whitelistFile != "" {
+		helpText = "Keys: 1-8 sort columns | r reset | enter details | w add to whitelist | q quit"
+	} else {
+		helpText = "Keys: 1-8 sort columns | r reset | enter details | q quit"
+	}
+	help := helpStyle.Render(helpText)
 	b.WriteString(help + "\n\n")
 
 	// Table
@@ -412,7 +485,7 @@ func (m *Model) getSortedConnections() []*ConnectionData {
 	return connections
 }
 
-func (m *Model) renderPopup() string {
+func (m *Model) renderDetailsPopup() string {
 	data := m.popupData
 	if data == nil {
 		return ""
@@ -488,10 +561,116 @@ func (m *Model) renderPopup() string {
 	return lipgloss.Place(terminalWidth, terminalHeight, lipgloss.Center, lipgloss.Center, popup)
 }
 
-func SendEvent(event *types.Event) tea.Cmd {
-	return func() tea.Msg {
-		return EventMsg{Event: event}
+func (m *Model) renderWhitelistPopup() string {
+	if m.popupData == nil {
+		return ""
 	}
+
+	data := m.popupData
+	var content strings.Builder
+
+	// Title
+	titleStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("212")).
+		Bold(true)
+	content.WriteString(titleStyle.Render("Add to Whitelist"))
+	content.WriteString("\n\n")
+
+	// Show process information
+	labelStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("86")).
+		Bold(true)
+
+	valueStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("255"))
+
+	addField := func(label, value string) {
+		content.WriteString(labelStyle.Render(label+": ") + valueStyle.Render(value) + "\n")
+	}
+
+	addField("Process", data.Event.Process)
+	addField("Process Path", data.Event.ProcessPath)
+	addField("SHA256", data.Event.ProcessSHA256)
+	content.WriteString("\n")
+
+	// Description input
+	content.WriteString(labelStyle.Render("Description: "))
+	content.WriteString("\n")
+	content.WriteString(m.whitelistInput.View())
+	content.WriteString("\n\n")
+
+	// Instructions
+	helpStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("241")).
+		Italic(true)
+
+	if !m.whitelistConfirming {
+		content.WriteString(helpStyle.Render("Enter a description, then press ENTER to confirm"))
+	} else {
+		content.WriteString(helpStyle.Render("Press ENTER again to add to whitelist, or ESC to cancel"))
+	}
+
+	// Style the popup
+	popupStyle := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("212")).
+		Padding(1, 2)
+
+	popup := popupStyle.Render(content.String())
+
+	// Center the popup
+	terminalWidth := m.width
+	terminalHeight := m.height
+
+	if terminalWidth == 0 {
+		terminalWidth = 80
+	}
+	if terminalHeight == 0 {
+		terminalHeight = 24
+	}
+
+	return lipgloss.Place(terminalWidth, terminalHeight, lipgloss.Center, lipgloss.Center, popup)
+}
+
+func (m *Model) addToWhitelist() error {
+	if m.popupData == nil || m.whitelistFile == "" {
+		return fmt.Errorf("no whitelist file configured")
+	}
+
+	data := m.popupData
+	description := strings.TrimSpace(m.whitelistInput.Value())
+	if description == "" {
+		description = "Added from TUI"
+	}
+
+	// Prepare the entry to append
+	var entry strings.Builder
+	entry.WriteString("\n")
+	entry.WriteString(fmt.Sprintf("# %s\n", description))
+	entry.WriteString(fmt.Sprintf("# Process: %s\n", data.Event.Process))
+	entry.WriteString(fmt.Sprintf("# Path: %s\n", data.Event.ProcessPath))
+	entry.WriteString(fmt.Sprintf("# Added: %s\n", time.Now().Format("2006-01-02 15:04:05")))
+	entry.WriteString(fmt.Sprintf("%s\n", data.Event.ProcessSHA256))
+
+	// Append to whitelist file
+	file, err := os.OpenFile(m.whitelistFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to open whitelist file: %w", err)
+	}
+	defer file.Close()
+
+	if _, err := file.WriteString(entry.String()); err != nil {
+		return fmt.Errorf("failed to write to whitelist file: %w", err)
+	}
+
+	// Update the process cache's whitelist filter
+	if m.processCache != nil {
+		if err := m.processCache.GetWhitelistFilter().AddHash(data.Event.ProcessSHA256); err != nil {
+			return fmt.Errorf("failed to add hash to filter: %w", err)
+		}
+	}
+
+	return nil
 }
 
 // evictCacheIfNeeded performs size-based cache eviction (time-based is handled by timer)

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -327,9 +327,9 @@ func (m *Model) View() string {
 
 	var helpText string
 	if m.whitelistFile != "" {
-		helpText = "Keys: 1-8 sort columns | r reset | enter details | w add to whitelist | q quit"
+		helpText = "Keys: 1-8 sort columns | enter details | w whitelist process | r reset | q quit"
 	} else {
-		helpText = "Keys: 1-8 sort columns | r reset | enter details | q quit"
+		helpText = "Keys: 1-8 sort columns | enter details | r reset | q quit"
 	}
 	help := helpStyle.Render(helpText)
 	b.WriteString(help + "\n\n")

--- a/whitelist.example
+++ b/whitelist.example
@@ -1,5 +1,0 @@
-# Whitelist file for egress-tracer
-# One SHA256 hash per line
-# Lines starting with # are comments and will be ignored
-# Empty lines are also ignored
-

--- a/whitelist.example
+++ b/whitelist.example
@@ -3,9 +3,3 @@
 # Lines starting with # are comments and will be ignored
 # Empty lines are also ignored
 
-# Example hashes (these are not real process hashes)
-# d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2
-# a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1
-
-# Add your process SHA256 hashes below:
-c8addf60507e54d9b5ca766492fec5386c5bf8775d7c6748c305a4e01f7f7145

--- a/whitelist.example
+++ b/whitelist.example
@@ -1,0 +1,11 @@
+# Whitelist file for egress-tracer
+# One SHA256 hash per line
+# Lines starting with # are comments and will be ignored
+# Empty lines are also ignored
+
+# Example hashes (these are not real process hashes)
+# d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2
+# a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1
+
+# Add your process SHA256 hashes below:
+c8addf60507e54d9b5ca766492fec5386c5bf8775d7c6748c305a4e01f7f7145


### PR DESCRIPTION
Introduce a whitelist filter that allows users to specify SHA256 hashes of processes to ignore in the output. Update command-line options and TUI functionality to support management of the whitelist feature, including error handling and enhanced documentation.